### PR TITLE
refactor(scripts): split deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,34 +105,50 @@
 
     ```bash
     $ ./scripts/deploy.sh
-    ### Installing cert-manager
+    # Deploying dependencies
+
+    ## Timeout when deploying dependencies: 5m
+
+    ### Deploying cert-manager
 
     customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
     customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
     customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
-    customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io created
+    ...snip...
+    deployment.apps/cert-manager created
+    deployment.apps/cert-manager-webhook created
+    mutatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
+    validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
 
-    # ... snip lots of output ...
+    ### Deploying traefik
+
+    NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
+    traefik traefik-system  2               2021-01-18 23:21:02.93080462 +0100 CET  deployed        traefik-9.12.3  2.3.6
+
+    ### Deploying mariadb
+
+    NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
+    mariadb mariadb         2               2021-01-18 23:21:09.06076444 +0100 CET  deployed        mariadb-9.2.2   10.5.8
+
+    ### Waiting for traefik to report ready
+
+    deployment.apps/traefik condition met
+
+    ### Waiting for mariadb to report ready
+
+    statefulset rolling update complete 1 pods at revision mariadb-d766ccf4f...
+
+    ## Deploying dependencies complete
+
+    # Deploying Notary and the registry
+
+    ## Timeout when deploying Notary and the registry: 5m
 
     ### Deploying notary and registry
 
     namespace/notary created
     configmap/notaryserver-9g226fhg7t created
-    configmap/notarysigner-hc4767dmg9 created
-    configmap/scripts-k7fkbhf5gh created
-    secret/notary-ca created
-    secret/notaryserver-82f9bt4cct created
-    secret/notarysigner-td6hb4gbht created
-    service/notaryserver created
-    service/notarysigner created
-    service/registry created
-    deployment.apps/notaryserver created
-    deployment.apps/notarysigner created
-    deployment.apps/registry created
-    job.batch/migrate created
-    certificate.cert-manager.io/notaryserver-tls created
-    certificate.cert-manager.io/notarysigner-tls created
-    certificate.cert-manager.io/registry-tls created
+    ...snip...
     issuer.cert-manager.io/notary-ca created
     ingress.networking.k8s.io/notary created
 
@@ -142,9 +158,13 @@
 
     ### Waiting for deployments to report ready
 
-    deployment.apps/notarysigner condition met
     deployment.apps/registry condition met
+    deployment.apps/notarysigner condition met
     deployment.apps/notaryserver condition met
+
+    ## Deploying notary and registry complete
+
+    # Deployment complete
     ```
 
 5.  Validate that we can reach the registry by retagging an image and pushing it.

--- a/scripts/deploy-dependencies.sh
+++ b/scripts/deploy-dependencies.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname $0)/.."
+
+GLOBAL_TIMEOUT=5m
+
+printf "## Timeout when deploying dependencies: ${GLOBAL_TIMEOUT}\n\n"
+
+printf "### Deploying cert-manager\n\n"
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
+
+printf "\n### Deploying traefik\n\n"
+helm upgrade --install --namespace traefik-system --create-namespace traefik --repo https://helm.traefik.io/traefik traefik --version 9.12.3 > /dev/null
+helm list --namespace traefik-system
+
+printf "\n### Deploying mariadb\n\n"
+# work around to make this script idempotent. The helm chart doesn't allow
+# running an upgrade without providing it the root password.
+if kubectl get secret mariadb --namespace mariadb > /dev/null 2>&1 ; then
+    printf "Found mariadb secret, reusing root password\n"
+    MARIADB_ROOT_PASSWORD_VALUES_BLOCK="
+auth:
+    rootPassword: $(kubectl get secret mariadb --namespace mariadb -o jsonpath='{.data.mariadb-root-password}' | base64 -d)
+"
+fi
+
+helm upgrade --install --namespace mariadb --create-namespace mariadb --repo https://charts.bitnami.com/bitnami mariadb --version 9.2.2 --values - > /dev/null <<EOF
+${MARIADB_ROOT_PASSWORD_VALUES_BLOCK:-}
+
+primary:
+    persistence:
+        enabled: false
+
+initdbScripts:
+    create_signer_database.sql: |
+        CREATE DATABASE IF NOT EXISTS notarysigner;
+        CREATE USER 'signer'@'%' IDENTIFIED BY 'signer';
+        GRANT ALL PRIVILEGES ON notarysigner.* TO 'signer'@'%';
+
+    create_server_database.sql: |
+        CREATE DATABASE IF NOT EXISTS notaryserver;
+        CREATE USER 'server'@'%' IDENTIFIED BY 'server';
+        GRANT ALL PRIVILEGES ON notaryserver.* TO 'server'@'%';
+EOF
+
+helm list --namespace mariadb
+
+printf "\n### Waiting for traefik to report ready\n\n"
+kubectl wait --for=condition=Available deployments --all --namespace traefik-system  --timeout=${GLOBAL_TIMEOUT}
+
+printf "\n### Waiting for mariadb to report ready\n\n"
+kubectl rollout status statefulsets/mariadb --namespace mariadb --timeout=${GLOBAL_TIMEOUT}
+
+printf "\n## Deploying dependencies complete\n\n"

--- a/scripts/deploy-notary.sh
+++ b/scripts/deploy-notary.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname $0)/.."
+
+GLOBAL_TIMEOUT=5m
+
+printf "## Timeout when deploying Notary and the registry: ${GLOBAL_TIMEOUT}\n\n"
+
+printf "### Deploying notary and registry\n\n"
+kustomize build deploy | kubectl apply -f -
+
+printf "\n### Waiting for migration job to complete\n\n"
+kubectl wait --for=condition=Complete  jobs        --all --namespace notary --timeout=${GLOBAL_TIMEOUT}
+
+printf "\n### Waiting for deployments to report ready\n\n"
+kubectl wait --for=condition=Available deployments --all --namespace notary --timeout=${GLOBAL_TIMEOUT}
+
+printf "\n## Deploying notary and registry complete\n\n"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,57 +4,12 @@ set -euo pipefail
 
 cd "$(dirname $0)/.."
 
-GLOBAL_TIMEOUT=5m
+printf "# Deploying dependencies\n\n"
 
-printf "## Global timeout: ${GLOBAL_TIMEOUT}\n\n"
+./scripts/deploy-dependencies.sh
 
-printf "### Installing cert-manager\n\n"
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
+printf "# Deploying Notary and the registry\n\n"
 
-printf "\n#### Installing traefik\n\n"
-helm upgrade --install --namespace traefik-system --create-namespace traefik --repo https://helm.traefik.io/traefik traefik --version 9.12.3
+./scripts/deploy-notary.sh
 
-printf "\n#### Installing mariadb\n\n"
-# work around to make this script idempotent. The helm chart doesn't allow
-# running an upgrade without providing it the root password.
-if kubectl get secret mariadb --namespace mariadb > /dev/null 2>&1 ; then
-    printf "Found mariadb secret, reusing root password\n"
-    MARIADB_ROOT_PASSWORD_VALUES_BLOCK="
-auth:
-    rootPassword: $(kubectl get secret mariadb --namespace mariadb -o jsonpath='{.data.mariadb-root-password}' | base64 -d)
-"
-fi
-
-helm upgrade --install --namespace mariadb --create-namespace mariadb --repo https://charts.bitnami.com/bitnami mariadb --version 9.2.2 --values - <<EOF
-${MARIADB_ROOT_PASSWORD_VALUES_BLOCK:-}
-
-primary:
-    persistence:
-        enabled: false
-
-initdbScripts:
-    create_signer_database.sql: |
-        CREATE DATABASE IF NOT EXISTS notarysigner;
-        CREATE USER 'signer'@'%' IDENTIFIED BY 'signer';
-        GRANT ALL PRIVILEGES ON notarysigner.* TO 'signer'@'%';
-
-    create_server_database.sql: |
-        CREATE DATABASE IF NOT EXISTS notaryserver;
-        CREATE USER 'server'@'%' IDENTIFIED BY 'server';
-        GRANT ALL PRIVILEGES ON notaryserver.* TO 'server'@'%';
-EOF
-
-printf "\n### Waiting for traefik to report ready\n\n"
-kubectl wait --for=condition=Available deployments --all --namespace traefik-system  --timeout=${GLOBAL_TIMEOUT}
-
-printf "\n### Waiting for mariadb to report ready\n\n"
-kubectl rollout status statefulsets/mariadb --namespace mariadb --timeout=${GLOBAL_TIMEOUT}
-
-printf "\n### Deploying notary and registry\n\n"
-kustomize build deploy | kubectl apply -f -
-
-printf "\n### Waiting for migration job to complete\n\n"
-kubectl wait --for=condition=Complete  jobs        --all --namespace notary --timeout=${GLOBAL_TIMEOUT}
-
-printf "\n### Waiting for deployments to report ready\n\n"
-kubectl wait --for=condition=Available deployments --all --namespace notary --timeout=${GLOBAL_TIMEOUT}
+printf "# Deployment complete\n"


### PR DESCRIPTION
Use separate scripts so people who don't want the dependencies can just install Notary.